### PR TITLE
Unify pkgmgr

### DIFF
--- a/conf/init-common.el
+++ b/conf/init-common.el
@@ -30,6 +30,7 @@
 ;; disable beep
 (setq ring-bell-function '(lambda ()))
 ;; visible bell on mode line
+(ensure-package 'mode-line-bell)
 (use-package mode-line-bell
   :hook
   (after-init . mode-line-bell-mode))
@@ -115,7 +116,8 @@
 
 
 ;; ibuffer
-(use-package ibuffer-vc)
+(ensure-package 'ibuffer-vc)
+(require 'ibuffer-vc)
 (global-set-key [remap list-buffers] #'ibuffer)
 (add-hook 'ibuffer-hook (lambda ()
                           (ibuffer-auto-mode)

--- a/conf/init-company.el
+++ b/conf/init-company.el
@@ -5,6 +5,7 @@
 ;;; Code:
 
 
+(ensure-package 'company)
 (use-package company
   :diminish
   :hook
@@ -64,6 +65,7 @@
                       company-dabbrev
                       )))
 
+(ensure-package 'company-statistics)
 (use-package company-statistics
   :after company
   :config

--- a/conf/init-consult.el
+++ b/conf/init-consult.el
@@ -62,7 +62,7 @@
 
 
 (use-package consult
-  ;; Replace bindings. Lazily loaded due by `use-package'.
+  :demand
   :bind (;; C-c bindings in `mode-specific-map'
          ("C-c M-x" . consult-mode-command)
          ;; ("C-c h" . consult-history)

--- a/conf/init-consult.el
+++ b/conf/init-consult.el
@@ -4,6 +4,7 @@
 
 ;;; Code:
 
+(ensure-package 'vertico)
 (use-package vertico
   :init
   (vertico-mode)
@@ -22,6 +23,7 @@
 
 ;; Duplicate setup for orderless. Ensure the case when consult and
 ;; corfu are not be used together.
+(ensure-package 'orderless)
 (use-package orderless
   :init
   (setq completion-styles '(orderless basic)
@@ -31,6 +33,7 @@
   (setq completion-cycle-threshold 4))
 
 
+(ensure-package 'embark)
 (use-package embark
   :bind
   (:map vertico-map
@@ -61,6 +64,7 @@
                  (window-parameters (mode-line-format . none)))))
 
 
+(ensure-package 'consult)
 (use-package consult
   :demand
   :bind (;; C-c bindings in `mode-specific-map'
@@ -191,18 +195,21 @@
 )
 
 
+(ensure-package 'embark-consult)
 (use-package embark-consult
   :after consult embark
   :hook
   (embark-collect-mode-hook . embark-consult-preview-minor-mode))
 
 
+(ensure-package 'consult-projectile)
 (use-package consult-projectile
   :after consult projectile
   :bind
   (:map projectile-mode-map
         ("C-c SPC" . consult-projectile)))
 
+(ensure-package 'marginalia)
 (use-package marginalia
   :init
   (marginalia-mode)

--- a/conf/init-corfu.el
+++ b/conf/init-corfu.el
@@ -9,6 +9,7 @@
 
 ;; Duplicate setup for orderless. Ensure the case when consult and
 ;; corfu are not be used together.
+(ensure-package 'orderless)
 (use-package orderless
   :init
   (setq completion-styles '(orderless basic)
@@ -17,6 +18,7 @@
         completion-category-overrides nil)
   (setq completion-cycle-threshold 4))
 
+(ensure-package 'corfu)
 (use-package corfu
   :bind
   (:map corfu-map
@@ -40,12 +42,14 @@
   (global-corfu-mode)
   (corfu-popupinfo-mode))
 
+(ensure-package 'corfu-terminal)
 (use-package corfu-terminal
   :after corfu
   :init
   (unless (display-graphic-p)
     (corfu-terminal-mode +1)))
 
+(ensure-package 'cape)
 (use-package cape
   :after corfu
   :init
@@ -64,6 +68,7 @@
   )
 
 
+(ensure-package 'kind-icon)
 (use-package kind-icon
   :after corfu
   :custom

--- a/conf/init-editor.el
+++ b/conf/init-editor.el
@@ -22,6 +22,7 @@
 
 (global-so-long-mode 1)
 
+(ensure-package 'vlf)
 (use-package vlf
   :config
   (defun ffap-vlf ()
@@ -56,6 +57,7 @@
 
 
 ;; paren highlight style
+(ensure-package 'paren)
 (use-package paren
   :custom
   (show-paren-style 'parenthesis)
@@ -90,7 +92,8 @@
 (add-hook 'prog-mode-hook 'display-line-numbers-mode)
 
 
-(use-package unfill)
+(ensure-package 'unfill)
+(require 'unfill)
 
 
 (add-hook 'after-init-hook 'global-subword-mode)
@@ -112,6 +115,7 @@
 (with-eval-after-load 'flyspell
   (diminish 'flyspell-mode))
 
+(ensure-package 'flyspell-correct)
 (use-package flyspell-correct
   :after flyspell
   :bind
@@ -136,6 +140,7 @@
                 (< (buffer-size other-buffer) (* 1 1024 1024))))
 
 
+(ensure-package 'symbol-overlay)
 (use-package symbol-overlay
   :hook
   (text-mode . symbol-overlay-mode)
@@ -145,13 +150,15 @@
   ([f4] . symbol-overlay-jump-next))
 
 
+(ensure-package 'whole-line-or-region)
 (use-package whole-line-or-region
   :diminish whole-line-or-region-local-mode
   :hook
   (after-init . whole-line-or-region-global-mode))
 
 
-(use-package separedit)
+(ensure-package 'separedit)
+(require 'separedit)
 
 
 (define-key global-map (kbd "M-c") #'capitalize-dwim)

--- a/conf/init-elpa.el
+++ b/conf/init-elpa.el
@@ -26,6 +26,13 @@
 (package-initialize)
 
 
+(defun ensure-package (package)
+  "Ensure PACKAGE is installed.
+This is the ELPA version for the same interface."
+  (unless (package-installed-p package)
+    (package-install package)))
+
+
 ;; use-package
 ;; Since Emacs 29.1, use-package is a built-in.
 (when (version< emacs-version "29.1")
@@ -33,7 +40,7 @@
     (package-refresh-contents)
     (package-install 'use-package))
   (eval-and-compile
-    (setq use-package-always-ensure t)
+    ;; (setq use-package-always-ensure t)
     ;; (setq use-package-always-defer nil)
     ;; (setq use-package-always-demand nil)
     ;; (setq use-package-expand-minimally nil)
@@ -41,14 +48,16 @@
   (eval-when-compile
     (require 'use-package)))
 
-(setq use-package-always-ensure t)
+;; (setq use-package-always-ensure t)
 (setq use-package-enable-imenu-support t)
 
 
-(use-package diminish)
+(ensure-package 'diminish)
+(require 'diminish)
 
 
 ;; bootstrap quelpa as an addition for melpa
+(ensure-package 'quelpa)
 (use-package quelpa
   :commands quelpa
   :custom

--- a/conf/init-helm.el
+++ b/conf/init-helm.el
@@ -5,6 +5,7 @@
 ;;; Code:
 
 
+(ensure-package 'helm)
 (use-package helm
   :diminish
   :demand
@@ -83,13 +84,17 @@
 ;; C-x C-s to make result to a buffer
 ;; C-c C-p to start edit with wgrep-helm
 ;; C-c C-c or C-x C-s when edit finish
-(use-package wgrep-helm
-  :after helm)
+(ensure-package 'wgrep-helm)
+(with-eval-after-load 'helm
+  (require 'wgrep-helm))
 
 
-(use-package helm-ls-git
-  :after helm)
+(ensure-package 'helm-ls-git)
+(with-eval-after-load 'helm
+  (require 'helm-ls-git))
 
+
+(ensure-package 'helm-xref)
 (use-package helm-xref
   :after helm
   :init
@@ -99,10 +104,12 @@
         ))
 
 
+(ensure-package 'flyspell-correct-helm)
 (use-package flyspell-correct-helm
   :after (helm flyspell-correct))
 
 
+(ensure-package 'helm-projectile)
 (use-package helm-projectile
   :after (helm projectile)
   :init

--- a/conf/init-ime.el
+++ b/conf/init-ime.el
@@ -6,6 +6,7 @@
 
 
 ;; setup for pyim
+(ensure-package 'pyim)
 (use-package pyim
   :demand
   :bind
@@ -32,6 +33,7 @@
   ;; (setq pyim-default-scheme 'cangjie)
 
   ;; 五笔设置
+  (ensure-package 'pyim-wbdict)
   (use-package pyim-wbdict
     :config
     (pyim-wbdict-v86-single-enable))

--- a/conf/init-ivy.el
+++ b/conf/init-ivy.el
@@ -5,9 +5,11 @@
 ;;; Code:
 
 
-(use-package smex)
+(ensure-package 'smex)
+(require 'smex)
 
 
+(ensure-package 'ivy)
 (use-package ivy
   :diminish
   :hook (after-init . ivy-mode)
@@ -25,6 +27,7 @@
   (enable-recursive-minibuffers t))
 
 
+(ensure-package 'swiper)
 (use-package swiper
   :bind
   ([remap isearch-forward] . swiper-isearch)
@@ -33,6 +36,7 @@
         ("C-s" . swiper)))
 
 
+(ensure-package 'counsel)
 (use-package counsel
   :diminish
   :hook (ivy-mode . counsel-mode)
@@ -87,6 +91,7 @@
   (counsel-find-file-ignore-regexp "\\(?:\\`\\(?:\\.\\|__\\)\\|elc\\|pyc$\\)"))
 
 
+(ensure-package 'ivy-rich)
 (use-package ivy-rich
   :after counsel
   :config
@@ -129,6 +134,7 @@
   (ivy-rich-mode t))
 
 
+(ensure-package 'ivy-xref)
 (use-package ivy-xref
   :init
   (when (>= emacs-major-version 27)
@@ -136,10 +142,12 @@
   (setq xref-show-xrefs-function #'ivy-xref-show-xrefs))
 
 
-(use-package flyspell-correct-ivy
-  :after flyspell-correct)
+(ensure-package 'flyspell-correct-ivy)
+(with-eval-after-load 'flyspell-correct
+  (require 'flyspell-correct-ivy))
 
 
+(ensure-package 'counsel-projectile)
 (use-package counsel-projectile
   :after projectile
   :init

--- a/conf/init-lsp.el
+++ b/conf/init-lsp.el
@@ -8,7 +8,8 @@
 (setq read-process-output-max (* 1024 1024))
 
 
-(use-package eglot)
+;; (ensure-package 'eglot)
+(require 'eglot)
 
 
 (provide 'init-lsp)

--- a/conf/init-modes.el
+++ b/conf/init-modes.el
@@ -5,6 +5,7 @@
 ;;; Code:
 
 
+(ensure-package 'markdown-mode)
 (use-package markdown-mode
   :custom
   (markdown-header-scaling nil)
@@ -65,22 +66,26 @@
                             (flyspell-mode -1)))
 
 
-(use-package dockerfile-mode
-  :mode
-  ("Dockerfile\\'" . dockerfile-mode))
+(ensure-package 'dockerfile-mode)
+(require 'dockerfile-mode)
+(add-to-list 'auto-mode-alist '("Dockerfile\\'" . dockerfile-mode))
 
 
-(use-package yaml-mode)
+(ensure-package 'yaml-mode)
+(require 'yaml-mode)
 
 
-(use-package go-mode)
+(ensure-package 'go-mode)
+(require 'go-mode)
 
 
-(use-package bazel)
+(ensure-package 'bazel)
+(require 'bazel)
 
 
 ;; terraform mode
-(use-package hcl-mode)
+(ensure-package 'hcl-mode)
+(require 'hcl-mode)
 (add-to-list 'auto-mode-alist '("\\.tf\\'" . hcl-mode))
 (add-to-list 'auto-mode-alist '("\\.tfvars\\'" . hcl-mode))
 

--- a/conf/init-straight.el
+++ b/conf/init-straight.el
@@ -37,12 +37,18 @@
   (load bootstrap-file nil 'nomessage))
 
 
+(defun ensure-package (package)
+  "Ensure PACKAGE is installed.
+This is the Straight version for the same interface."
+  (straight-use-package package))
+
+
 ;; use-package
 ;; Since Emacs 29.1, use-package is a built-in.
 (when (version< emacs-version "29.1")
   (straight-use-package 'use-package)
   (eval-and-compile
-    (setq use-package-always-ensure t)
+    ;; (setq use-package-always-ensure t)
     ;; (setq use-package-always-defer nil)
     ;; (setq use-package-always-demand nil)
     ;; (setq use-package-expand-minimally nil)
@@ -51,12 +57,13 @@
   (eval-when-compile
     (require 'use-package)))
 
-(setq use-package-always-ensure t)
+;; (setq use-package-always-ensure t)
 (setq use-package-enable-imenu-support t)
 (setq straight-use-package-by-default t)
 
 
-(use-package diminish)
+(ensure-package 'diminish)
+(require 'diminish)
 
 
 (provide 'init-straight)

--- a/conf/init-utils.el
+++ b/conf/init-utils.el
@@ -5,6 +5,7 @@
 ;;; Code:
 
 
+(ensure-package 'projectile)
 (use-package projectile
   :demand
   :bind
@@ -26,6 +27,7 @@
 
 
 ;; bm
+(ensure-package 'bm)
 (use-package bm
   :bind
   ("<f9>" . bm-toggle)
@@ -34,6 +36,7 @@
 
 
 ;; rg
+(ensure-package 'rg)
 (use-package rg
   :bind
   ("M-s r" . rg-dwim)
@@ -41,6 +44,7 @@
 
 
 ;; citre/ctags
+(ensure-package 'citre)
 (use-package citre
   :init
   (require 'citre-config)
@@ -109,16 +113,19 @@ This saves time when working on a large tags file."
 ;;   (dashboard-setup-startup-hook))
 
 
+(ensure-package 'magit)
 (use-package magit
   :bind
   ("C-x g" . magit-status))
 
 
+(ensure-package 'scratch)
 (use-package scratch
   :bind
   ("C-c s" . scratch))
 
 
+(ensure-package 'vundo)
 (use-package vundo
   :bind
   ("C-x u" . vundo))
@@ -126,6 +133,7 @@ This saves time when working on a large tags file."
 
 ;; Popper
 ;; Setup from roife@github
+(ensure-package 'popper)
 (use-package popper
   :bind (:map popper-mode-map
               ("M-<tab>"   . popper-cycle)

--- a/init.el
+++ b/init.el
@@ -54,7 +54,7 @@
 (add-to-list 'load-path (concat user-emacs-directory "local"))
 
 (require 'init-env)
-(require 'init-straight)
+(require 'init-elpa)
 (require 'init-common)
 (require 'init-editor)
 (require 'init-utils)


### PR DESCRIPTION
Add a function `ensure-package` for each package manager for "ensure a package is available" or "a package is installed".

I thought I can offload this job to `use-package`, however I feel create a function is more convenient, since I don't want to wrap all configurations with `use-package` and give myself some freedom for free-style. 

Switch the default package manager back to `package.el` from `straight`, because I feel `package.el` gives emacs shorter start time. However `straight` should be just available by alter the `init.el` file.